### PR TITLE
Support shared database and scope operations to owned nodes

### DIFF
--- a/src/grafeo_memory/manager.py
+++ b/src/grafeo_memory/manager.py
@@ -58,6 +58,7 @@ class _MemoryCore:
         *,
         embedder: EmbeddingClient,
         reranker: object | None = None,
+        db: GrafeoDBProtocol | None = None,
     ):
         import grafeo
 
@@ -67,7 +68,10 @@ class _MemoryCore:
         self._reranker = reranker
 
         self._db: GrafeoDBProtocol
-        if self._config.db_path:
+        self._db_external = db is not None
+        if db is not None:
+            self._db = db
+        elif self._config.db_path:
             self._db = grafeo.GrafeoDB(self._config.db_path)
         else:
             self._db = grafeo.GrafeoDB()
@@ -84,6 +88,14 @@ class _MemoryCore:
             Agent.instrument_all(self._config.instrument if self._config.instrument is not True else True)
 
     def _ensure_indexes(self) -> None:
+        """Create indexes for efficient memory queries.
+
+        Vector and text indexes are label-scoped to Memory nodes. Property
+        indexes (user_id, created_at, memory_type, name) are database-wide
+        because GrafeoDB's ``create_property_index`` does not support
+        label-scoped indexing. In a shared database these indexes will also
+        cover non-memory nodes — harmless but slightly wasteful.
+        """
         vp = self._config.vector_property
         tp = self._config.text_property
         dims = self._config.embedding_dimensions
@@ -108,7 +120,7 @@ class _MemoryCore:
         except Exception:
             logger.debug("Text index creation deferred or already exists")
 
-        # Property indexes for fast filtered lookups
+        # Property indexes for fast filtered lookups (database-wide; see docstring).
         for prop in ("user_id", "created_at", "memory_type"):
             with contextlib.suppress(Exception):
                 self._db.create_property_index(prop)
@@ -130,10 +142,15 @@ class _MemoryCore:
     def close(self) -> None:
         """Close the database connection.
 
+        If the database was externally provided via the ``db`` parameter,
+        it is **not** closed here — the caller owns its lifecycle.
+
         The async runner is intentionally NOT closed here — it is shared across
         sessions and cleaned up automatically at process exit via atexit. Closing
         it per-session corrupts httpx/anyio transport state on Windows.
         """
+        if self._db_external:
+            return
         if hasattr(self._db, "close"):
             self._db.close()  # ty: ignore[call-non-callable]
 
@@ -1162,7 +1179,7 @@ class _MemoryCore:
 
         if direction in ("forward", "both"):
             query = (
-                f"MATCH (m)-[:LEADS_TO*1..{max_depth}]->(rest:Memory) "
+                f"MATCH (m:{MEMORY_LABEL})-[:{LEADS_TO_EDGE}*1..{max_depth}]->(rest:{MEMORY_LABEL}) "
                 f"WHERE id(m) = $mid{user_filter} "
                 f"RETURN id(rest), rest.text, rest.created_at, rest.session_id "
                 f"ORDER BY rest.created_at"
@@ -1192,7 +1209,7 @@ class _MemoryCore:
 
         if direction in ("backward", "both"):
             query = (
-                f"MATCH (rest:Memory)-[:LEADS_TO*1..{max_depth}]->(m) "
+                f"MATCH (rest:{MEMORY_LABEL})-[:{LEADS_TO_EDGE}*1..{max_depth}]->(m:{MEMORY_LABEL}) "
                 f"WHERE id(m) = $mid{user_filter} "
                 f"RETURN id(rest), rest.text, rest.created_at, rest.session_id "
                 f"ORDER BY rest.created_at"
@@ -1247,6 +1264,10 @@ class _MemoryCore:
         Runs pagerank, betweenness centrality, and louvain community detection.
         Results are stored as node properties for fast access during search scoring.
         Only runs when enable_graph_algorithms is True and the graph has changed.
+
+        Only Memory and Entity nodes are updated. Algorithm computation may span
+        the full graph (GrafeoDB API limitation), so scores can be influenced by
+        non-memory topology when using a shared database.
         """
         if not self._config.enable_graph_algorithms or not self._graph_dirty:
             return
@@ -1256,21 +1277,32 @@ class _MemoryCore:
             logger.debug("Graph algorithms not available on this db instance")
             return
 
+        # Collect IDs of nodes we own so we only write to Memory/Entity nodes.
+        owned_ids: set[int] = set()
+        for node_id, _ in self._db.get_nodes_by_label(MEMORY_LABEL):
+            owned_ids.add(node_id)
+        for node_id, _ in self._db.get_nodes_by_label(ENTITY_LABEL):
+            owned_ids.add(node_id)
+        if not owned_ids:
+            return
+
         algos = self._db.algorithms
 
         try:
             ranks = algos.pagerank(0.85, 100, 1e-6)  # ty: ignore[unresolved-attribute]
             for node_id, score in ranks.items():
-                with contextlib.suppress(Exception):
-                    self._db.set_node_property(node_id, "_pagerank", score)
+                if node_id in owned_ids:
+                    with contextlib.suppress(Exception):
+                        self._db.set_node_property(node_id, "_pagerank", score)
         except Exception:
             logger.debug("pagerank computation failed", exc_info=True)
 
         try:
             centrality = algos.betweenness_centrality(True)  # ty: ignore[unresolved-attribute]
             for node_id, score in centrality.items():
-                with contextlib.suppress(Exception):
-                    self._db.set_node_property(node_id, "_betweenness", score)
+                if node_id in owned_ids:
+                    with contextlib.suppress(Exception):
+                        self._db.set_node_property(node_id, "_betweenness", score)
         except Exception:
             logger.debug("betweenness_centrality computation failed", exc_info=True)
 
@@ -1278,8 +1310,9 @@ class _MemoryCore:
             result = algos.louvain(1.0)  # ty: ignore[unresolved-attribute]
             communities = result.get("communities", {}) if isinstance(result, dict) else {}
             for node_id, community_id in communities.items():
-                with contextlib.suppress(Exception):
-                    self._db.set_node_property(node_id, "_community", community_id)
+                if node_id in owned_ids:
+                    with contextlib.suppress(Exception):
+                        self._db.set_node_property(node_id, "_community", community_id)
         except Exception:
             logger.debug("louvain community detection failed", exc_info=True)
 
@@ -1324,19 +1357,17 @@ class _MemoryCore:
 
     def _find_or_create_entity(self, entity: Entity, user_id: str) -> int:
         try:
-            nodes = self._db.find_nodes_by_property("name", entity.name)
+            rows = self._db.execute(
+                f"MATCH (e:{ENTITY_LABEL}) WHERE e.name = $name AND e.user_id = $uid RETURN id(e)",
+                {"name": entity.name, "uid": user_id},
+            )
+            for row in rows:
+                if isinstance(row, dict):
+                    vals = list(row.values())
+                    if vals:
+                        return int(vals[0])
         except Exception:
             logger.warning("_find_or_create_entity: lookup failed for %r", entity.name, exc_info=True)
-            nodes = []
-
-        for nid in nodes:
-            node = self._db.get_node(nid)
-            if node is None:
-                continue
-            props = _get_props(node)
-            labels = node.labels if hasattr(node, "labels") else []
-            if ENTITY_LABEL in labels and props.get("user_id") == user_id:
-                return nid
 
         node = self._db.create_node(
             [ENTITY_LABEL],
@@ -1594,11 +1625,6 @@ class _MemoryCore:
         except Exception:
             pass
 
-        try:
-            db_info = self._db.info()
-        except Exception:
-            db_info = {}
-
         total = semantic + procedural + episodic
         return MemoryStats(
             total_memories=total,
@@ -1607,7 +1633,11 @@ class _MemoryCore:
             episodic_count=episodic,
             entity_count=entity_count,
             relation_count=relation_count,
-            db_info=db_info if isinstance(db_info, dict) else {},
+            db_info={
+                "memory_node_count": total,
+                "entity_node_count": entity_count,
+                "relation_edge_count": relation_count,
+            },
         )
 
     def _set_importance_impl(self, memory_id: str, importance: float) -> bool:

--- a/src/grafeo_memory/mcp/resources.py
+++ b/src/grafeo_memory/mcp/resources.py
@@ -32,15 +32,17 @@ async def memory_config(ctx: Context[ServerSession, AppContext]) -> str:
 
 @mcp.resource("memory://stats")
 async def memory_stats(ctx: Context[ServerSession, AppContext]) -> str:
-    """Memory system statistics: node/edge counts, database info."""
+    """Memory system statistics: node/edge counts scoped to memory data."""
     manager = ctx.request_context.lifespan_context.manager
-    db = manager._db
-    try:
-        info = db.info()
-    except Exception:
-        info = {}
-    try:
-        stats = db.detailed_stats()  # ty: ignore[unresolved-attribute]
-    except Exception:
-        stats = {}
-    return json.dumps({"db_info": info, "db_stats": stats}, default=str)
+    stats = manager._stats_impl()
+    return json.dumps(
+        {
+            "total_memories": stats.total_memories,
+            "semantic_count": stats.semantic_count,
+            "procedural_count": stats.procedural_count,
+            "episodic_count": stats.episodic_count,
+            "entity_count": stats.entity_count,
+            "relation_count": stats.relation_count,
+        },
+        default=str,
+    )

--- a/src/grafeo_memory/search/graph.py
+++ b/src/grafeo_memory/search/graph.py
@@ -79,26 +79,27 @@ def graph_search(
     seen_memory_ids: set[str] = set()
 
     for entity in entities:
+        # Find Entity nodes by name, scoped to the Entity label and user.
+        entity_nids: list[int] = []
         try:
-            node_ids = db.find_nodes_by_property("name", entity.name)
+            rows = db.execute(
+                f"MATCH (e:{ENTITY_LABEL}) WHERE e.name = $name AND e.user_id = $uid RETURN id(e)",
+                {"name": entity.name, "uid": user_id},
+            )
+            entity_nids = [int(next(iter(r.values()))) for r in rows if isinstance(r, dict) and r]
         except Exception:
-            logger.warning("graph_search: find_nodes_by_property failed for entity=%r", entity.name, exc_info=True)
-            continue
+            logger.warning("graph_search: entity lookup failed for %r", entity.name, exc_info=True)
 
-        # Also try case-insensitive match
-        if not node_ids:
+        # Case-insensitive fallback
+        if not entity_nids:
             with contextlib.suppress(Exception):
-                node_ids = db.find_nodes_by_property("name", entity.name.lower())
+                rows = db.execute(
+                    f"MATCH (e:{ENTITY_LABEL}) WHERE toLower(e.name) = $name AND e.user_id = $uid RETURN id(e)",
+                    {"name": entity.name.lower(), "uid": user_id},
+                )
+                entity_nids = [int(next(iter(r.values()))) for r in rows if isinstance(r, dict) and r]
 
-        for entity_nid in node_ids:
-            node = db.get_node(entity_nid)
-            if node is None:
-                continue
-            props = _get_props(node)
-            labels = node.labels if hasattr(node, "labels") else []
-            if ENTITY_LABEL not in labels or props.get("user_id") != user_id:
-                continue
-
+        for entity_nid in entity_nids:
             # Traverse HAS_ENTITY edges back to Memory nodes
             try:
                 query_str = (

--- a/src/grafeo_memory/search/vector.py
+++ b/src/grafeo_memory/search/vector.py
@@ -377,12 +377,12 @@ def _matches_filters(props: dict, filters: dict) -> bool:
 
 def _get_node_relations(db: GrafeoDBProtocol, node_id: int) -> list[dict]:
     """Get relations for a memory node by traversing HAS_ENTITY and RELATION edges."""
-    from ..types import ENTITY_LABEL, HAS_ENTITY_EDGE, RELATION_EDGE
+    from ..types import ENTITY_LABEL, HAS_ENTITY_EDGE, MEMORY_LABEL, RELATION_EDGE
 
     relations: list[dict] = []
     try:
         query = (
-            f"MATCH (m)-[:{HAS_ENTITY_EDGE}]->(e:{ENTITY_LABEL})"
+            f"MATCH (m:{MEMORY_LABEL})-[:{HAS_ENTITY_EDGE}]->(e:{ENTITY_LABEL})"
             f"-[r:{RELATION_EDGE}]->(t:{ENTITY_LABEL}) "
             f"WHERE id(m) = $nid RETURN e.name, r.relation_type, t.name"
         )

--- a/tests/test_db_injection.py
+++ b/tests/test_db_injection.py
@@ -1,0 +1,117 @@
+"""Tests for injecting an external GrafeoDB instance into MemoryManager."""
+
+import grafeo
+from mock_llm import MockEmbedder, make_test_model
+
+from grafeo_memory import AsyncMemoryManager, MemoryAction, MemoryConfig, MemoryManager
+
+
+def _extraction_output():
+    """Standard extraction output for a single fact."""
+    return {
+        "facts": ["alice works at acme corp"],
+        "entities": [
+            {"name": "alice", "entity_type": "person"},
+            {"name": "acme_corp", "entity_type": "organization"},
+        ],
+        "relations": [
+            {"source": "alice", "target": "acme_corp", "relation_type": "works_at"},
+        ],
+    }
+
+
+class TestDBInjection:
+    """Test that an external GrafeoDB can be injected into MemoryManager."""
+
+    def test_inject_db_into_memory_manager(self):
+        """MemoryManager should use the provided db instead of creating its own."""
+        db = grafeo.GrafeoDB()
+        model = make_test_model([_extraction_output()])
+        embedder = MockEmbedder(16)
+        config = MemoryConfig(db_path=None, user_id="test_user", embedding_dimensions=16)
+
+        manager = MemoryManager(model, config, embedder=embedder, db=db)
+        assert manager._db is db
+        assert manager._db_external is True
+
+        events = manager.add("Alice works at Acme Corp")
+        assert len(events) >= 1
+        assert events[0].action == MemoryAction.ADD
+
+        # Verify data was written to the shared db
+        memories = db.get_nodes_by_label("Memory")
+        assert len(memories) >= 1
+
+        manager.close()
+
+    def test_inject_db_into_async_memory_manager(self):
+        """AsyncMemoryManager should use the provided db instead of creating its own."""
+        import asyncio
+
+        db = grafeo.GrafeoDB()
+        model = make_test_model([_extraction_output()])
+        embedder = MockEmbedder(16)
+        config = MemoryConfig(db_path=None, user_id="test_user", embedding_dimensions=16)
+
+        manager = AsyncMemoryManager(model, config, embedder=embedder, db=db)
+        assert manager._db is db
+        assert manager._db_external is True
+
+        events = asyncio.run(manager.add("Alice works at Acme Corp"))
+        assert len(events) >= 1
+
+        manager.close()
+
+    def test_default_creates_internal_db(self):
+        """Omitting db should preserve existing behavior — internal DB is created."""
+        model = make_test_model([{"facts": []}])
+        embedder = MockEmbedder(16)
+        config = MemoryConfig(db_path=None, user_id="test_user", embedding_dimensions=16)
+
+        manager = MemoryManager(model, config, embedder=embedder)
+        assert manager._db_external is False
+        assert manager._db is not None
+
+        manager.close()
+
+
+class TestCloseLifecycle:
+    """Test that close() respects external DB ownership."""
+
+    def test_close_does_not_close_external_db(self):
+        """When db is externally provided, close() should leave it open."""
+        db = grafeo.GrafeoDB()
+        model = make_test_model([{"facts": []}])
+        embedder = MockEmbedder(16)
+        config = MemoryConfig(db_path=None, user_id="test_user", embedding_dimensions=16)
+
+        manager = MemoryManager(model, config, embedder=embedder, db=db)
+        manager.close()
+
+        # DB should still be usable after manager.close()
+        node = db.create_node(["Test"], {"name": "after_close"})
+        assert node.id is not None
+
+    def test_close_closes_internal_db(self):
+        """When db is internally created, close() should close it."""
+        model = make_test_model([{"facts": []}])
+        embedder = MockEmbedder(16)
+        config = MemoryConfig(db_path=None, user_id="test_user", embedding_dimensions=16)
+
+        manager = MemoryManager(model, config, embedder=embedder)
+        manager.close()
+        # Internal DB should be closed — we just verify close() ran without error
+
+    def test_context_manager_does_not_close_external_db(self):
+        """Using `with` statement should not close an external db."""
+        db = grafeo.GrafeoDB()
+        model = make_test_model([{"facts": []}])
+        embedder = MockEmbedder(16)
+        config = MemoryConfig(db_path=None, user_id="test_user", embedding_dimensions=16)
+
+        with MemoryManager(model, config, embedder=embedder, db=db):
+            pass
+
+        # DB should still be usable
+        node = db.create_node(["Test"], {"name": "after_context"})
+        assert node.id is not None

--- a/tests/test_multi_tenant.py
+++ b/tests/test_multi_tenant.py
@@ -1,0 +1,203 @@
+"""Tests that grafeo-memory operations are scoped to Memory/Entity nodes.
+
+These tests create a shared in-memory GrafeoDB containing foreign "Domain"
+nodes alongside Memory/Entity nodes, then verify grafeo-memory never reads,
+modifies, or deletes the foreign nodes.
+"""
+
+import grafeo
+from mock_llm import MockEmbedder, make_test_model
+
+from grafeo_memory import MemoryConfig, MemoryManager
+from grafeo_memory.search.vector import _get_props
+from grafeo_memory.types import ENTITY_LABEL, MEMORY_LABEL
+
+
+def _extraction_output(facts=None, entities=None, relations=None):
+    return {
+        "facts": facts or ["alice works at acme corp"],
+        "entities": entities
+        or [
+            {"name": "alice", "entity_type": "person"},
+            {"name": "acme_corp", "entity_type": "organization"},
+        ],
+        "relations": relations or [{"source": "alice", "target": "acme_corp", "relation_type": "works_at"}],
+    }
+
+
+def _make_shared_manager(db, outputs, dims=16, **config_kwargs):
+    """Create a MemoryManager backed by a shared database."""
+    model = make_test_model(outputs)
+    embedder = MockEmbedder(dims)
+    defaults = {"db_path": None, "user_id": "test_user", "embedding_dimensions": dims}
+    defaults.update(config_kwargs)
+    config = MemoryConfig(**defaults)  # type: ignore[invalid-argument-type]
+    return MemoryManager(model, config, embedder=embedder, db=db)
+
+
+def _add_foreign_nodes(db):
+    """Add non-memory nodes to the database that grafeo-memory must not touch."""
+    n1 = db.create_node(["Domain", "CADPart"], {"name": "cylinder", "radius": 5.0})
+    n2 = db.create_node(["Domain", "CADPart"], {"name": "base_plate", "thickness": 2.0})
+    n3 = db.create_node(["Timeline"], {"step": 1, "operation": "extrude"})
+    db.create_edge(n1.id, n2.id, "CONNECTED_TO", {"joint": "weld"})
+    db.create_edge(n3.id, n1.id, "PRODUCES")
+    return [n1, n2, n3]
+
+
+class TestSharedDBMetrics:
+    """Graph algorithm scores must only be written to Memory/Entity nodes."""
+
+    def test_metrics_skip_foreign_nodes(self):
+        db = grafeo.GrafeoDB()
+        foreign = _add_foreign_nodes(db)
+
+        manager = _make_shared_manager(
+            db,
+            [_extraction_output(), _extraction_output(["bob likes hiking"])],
+            enable_graph_algorithms=True,
+        )
+        manager.add("Alice works at Acme Corp")
+        assert manager._graph_dirty is True
+
+        manager._recompute_graph_metrics()
+
+        # Foreign nodes must NOT have algorithm properties
+        for fnode in foreign:
+            node = db.get_node(fnode.id)
+            assert node is not None
+            props = _get_props(node)
+            assert "_pagerank" not in props, f"Foreign node {fnode.id} got _pagerank"
+            assert "_betweenness" not in props, f"Foreign node {fnode.id} got _betweenness"
+            assert "_community" not in props, f"Foreign node {fnode.id} got _community"
+
+        # Memory/Entity nodes SHOULD have algorithm properties
+        memory_nodes = db.get_nodes_by_label(MEMORY_LABEL)
+        assert len(memory_nodes) > 0
+        for mid, props in memory_nodes:
+            assert "_pagerank" in props, f"Memory node {mid} missing _pagerank"
+
+        manager.close()
+
+    def test_foreign_node_data_unchanged(self):
+        """Foreign node properties must be completely untouched after memory operations."""
+        db = grafeo.GrafeoDB()
+        foreign = _add_foreign_nodes(db)
+
+        manager = _make_shared_manager(db, [_extraction_output()])
+        manager.add("Alice works at Acme Corp")
+        manager.close()
+
+        # Verify foreign node properties are exactly as created
+        cyl = db.get_node(foreign[0].id)
+        assert cyl is not None
+        props = _get_props(cyl)
+        assert props["name"] == "cylinder"
+        assert props["radius"] == 5.0
+
+
+class TestSharedDBEntityLookup:
+    """Entity lookup must not match foreign nodes with the same name."""
+
+    def test_foreign_node_with_same_name_not_reused(self):
+        db = grafeo.GrafeoDB()
+        # Create a foreign node named "alice" — NOT an Entity
+        db.create_node(["Person"], {"name": "alice", "user_id": "test_user"})
+
+        manager = _make_shared_manager(db, [_extraction_output()])
+        manager.add("Alice works at Acme Corp")
+
+        # A new Entity node should have been created, not reusing the Person node
+        entity_nodes = db.get_nodes_by_label(ENTITY_LABEL)
+        entity_names = [props.get("name") for _, props in entity_nodes]
+        assert "alice" in entity_names
+
+        # The Person node should still exist untouched
+        person_nodes = db.get_nodes_by_label("Person")
+        assert len(person_nodes) == 1
+
+        manager.close()
+
+
+class TestSharedDBTemporalChain:
+    """temporal_chain must only traverse Memory nodes."""
+
+    def test_temporal_chain_ignores_foreign_nodes(self):
+        db = grafeo.GrafeoDB()
+
+        # Create a foreign node and a Memory node, connect them with LEADS_TO
+        foreign = db.create_node(["Domain"], {"name": "step_1", "text": "foreign data"})
+        memory = db.create_node(
+            [MEMORY_LABEL],
+            {"text": "a real memory", "user_id": "test_user", "memory_type": "semantic"},
+        )
+        db.create_edge(foreign.id, memory.id, "LEADS_TO")
+
+        manager = _make_shared_manager(db, [{"facts": []}])
+
+        # Query temporal chain starting from the foreign node — should get nothing
+        # because the query now requires (m:Memory)
+        result = manager.temporal_chain(str(foreign.id), direction="forward")
+        assert result == []
+
+        manager.close()
+
+
+class TestSharedDBStats:
+    """Stats must only report memory-scoped counts."""
+
+    def test_stats_exclude_foreign_nodes(self):
+        db = grafeo.GrafeoDB()
+        _add_foreign_nodes(db)
+
+        manager = _make_shared_manager(db, [_extraction_output()])
+        manager.add("Alice works at Acme Corp")
+
+        stats = manager.stats()
+        # Stats should reflect only Memory/Entity nodes, not the 3 foreign nodes
+        assert stats.total_memories >= 1
+        assert stats.entity_count >= 1
+
+        # db_info should contain scoped counts, not raw db.info()
+        assert "memory_node_count" in stats.db_info
+        assert stats.db_info["memory_node_count"] == stats.total_memories
+        assert stats.db_info["entity_node_count"] == stats.entity_count
+
+        manager.close()
+
+    def test_stats_db_info_has_no_total_node_count(self):
+        """db_info must not leak total database node counts."""
+        db = grafeo.GrafeoDB()
+        _add_foreign_nodes(db)
+
+        manager = _make_shared_manager(db, [{"facts": []}])
+        stats = manager.stats()
+
+        # Should not contain keys from raw db.info() like "node_count" or "total_nodes"
+        for key in stats.db_info:
+            assert key in ("memory_node_count", "entity_node_count", "relation_edge_count"), (
+                f"Unexpected key in db_info: {key}"
+            )
+
+        manager.close()
+
+
+class TestSharedDBDeleteAll:
+    """delete_all must only remove Memory nodes, not foreign nodes."""
+
+    def test_delete_all_preserves_foreign_nodes(self):
+        db = grafeo.GrafeoDB()
+        foreign = _add_foreign_nodes(db)
+
+        manager = _make_shared_manager(db, [_extraction_output()])
+        manager.add("Alice works at Acme Corp")
+        assert manager.stats().total_memories >= 1
+
+        manager.delete_all()
+        assert manager.stats().total_memories == 0
+
+        # All foreign nodes must still exist
+        for fnode in foreign:
+            assert db.get_node(fnode.id) is not None
+
+        manager.close()


### PR DESCRIPTION
## What this does

Two things:

1. You can now pass an existing `GrafeoDB` handle into `MemoryManager` (or `AsyncMemoryManager`) via a `db=` keyword argument. If you don't pass one, nothing changes. Closes #2.

2. All internal operations are now scoped to Memory and Entity nodes. Previously, several code paths assumed grafeo-memory owned the entire database. In a shared database, that meant writing properties to nodes it didn't create, running unscoped Cypher queries, and exposing raw database stats.

## What changed

**db injection** — `_MemoryCore.__init__` accepts `db: GrafeoDBProtocol | None`. When provided, `close()` leaves the database alone since it's not ours to close.

**Graph metrics were writing to every node in the database.** `_recompute_graph_metrics()` now collects Memory + Entity node IDs upfront and only writes `_pagerank`, `_betweenness`, `_community` to those. Foreign nodes are untouched. (Note: the algorithm computation still spans the full graph because the GrafeoDB algorithm API doesn't support label filtering. The scores may be influenced by other topology. This just prevents the writes from leaking.)

**Unlabeled nodes in Cypher queries.** `temporal_chain()` had `MATCH (m)-[:LEADS_TO*...]->` where `m` had no label, so it would match any node type. Same issue in `_get_node_relations()`. Both now use `(m:Memory)`.

**Entity lookup was doing a global scan then filtering in Python.** `_find_or_create_entity` and `graph_search` both called `find_nodes_by_property("name", x)` which returns every node in the database with that name, then looped through each one calling `get_node()` to check the label and user_id. That's N+1 FFI crossings into Rust per lookup.

Replaced with a single Cypher query:

```cypher
MATCH (e:Entity) WHERE e.name = $name AND e.user_id = $uid RETURN id(e)
```

One FFI call, filtering happens in the Rust engine. Correct and faster.

**Stats were exposing the whole database.** `_stats_impl()` called `db.info()` which returns counts for all node types. Now it returns only `memory_node_count`, `entity_node_count`, `relation_edge_count`. The MCP stats resource was going directly to the database too, now it uses the manager's scoped stats.

**Property indexes are database-wide** because `create_property_index()` doesn't take a label parameter. Nothing we can do about that in grafeo-memory, so I added a docstring noting the limitation. Might be worth adding label-scoped property indexes to grafeo proper at some point if you circle back to it.

## Tests

`tests/test_db_injection.py` (6 tests) covers the db injection feature, both sync and async, and verifies `close()` doesn't close an externally provided database.

`tests/test_multi_tenant.py` (7 tests) creates a shared database with foreign Domain/CADPart/Timeline nodes alongside memory data, then verifies:

- Graph metrics don't write to foreign nodes
- Foreign node properties stay untouched after memory operations
- A foreign node named "alice" doesn't get reused as an Entity
- `temporal_chain` doesn't traverse from a foreign node
- Stats only count memory data
- `delete_all` leaves foreign nodes alone

Full suite: 403 passed, 0 failures. Lint and type checks clean.